### PR TITLE
Handle edge cases with PAT token ENV import

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ const port = 3000
 const env_list = process.env
 for(var i in env_list) {
     if(i.startsWith('PAT_')){
-        org_pat_map[i.replace('PAT_', '')] = env_list[i].trim()
+        const pat_label = i.replace('PAT_', '')
+        if (pat_label) {
+            org_pat_map[pat_label] = env_list[i].trim()
+        }
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const port = 3000
 const env_list = process.env
 for(var i in env_list) {
     if(i.includes('PAT_')){
-        org_pat_map[i.replace('PAT_', '')] = env_list[i]
+        org_pat_map[i.replace('PAT_', '')] = env_list[i].trim()
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const port = 3000
 
 const env_list = process.env
 for(var i in env_list) {
-    if(i.includes('PAT_')){
+    if(i.startsWith('PAT_')){
         org_pat_map[i.replace('PAT_', '')] = env_list[i].trim()
     }
 }


### PR DESCRIPTION
One of the issues I've encountered is that I had a newline in my PAT token. This was causing the script to fail with the following:


```
node:_http_outgoing:702
validateHeaderValue(name, value);
^

TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Authorization"]
at ClientRequest.setHeader (node:_http_outgoing:702:3)
at new ClientRequest (node:_http_client:302:14)
at Object.request (node:https:381:10)
at RedirectableRequest._performRequest (/usr/src/app/node_modules/follow-redirects/index.js:265:24)
at new RedirectableRequest (/usr/src/app/node_modules/follow-redirects/index.js:61:8)
at Object.request (/usr/src/app/node_modules/follow-redirects/index.js:456:14)
at dispatchHttpRequest (/usr/src/app/node_modules/axios/lib/adapters/http.js:195:25)
at new Promise (<anonymous>)
at httpAdapter (/usr/src/app/node_modules/axios/lib/adapters/http.js:46:10)
at dispatchRequest (/usr/src/app/node_modules/axios/lib/core/dispatchRequest.js:52:10) {
code: 'ERR_INVALID_CHAR'
}
```

After figuring out the cause, I come up with simple and effective patch for such cases.

Additionally, I implemented some extra error handling to handle the case where the environment can be only `PAT_`. This would cause the script to attempt to use the empty key on the map, as PAT_ is stripped of it.